### PR TITLE
Fix Vector3f constructor to improve performance

### DIFF
--- a/Dart_RaytracerDemo/web/SimpleRaytracer.dart
+++ b/Dart_RaytracerDemo/web/SimpleRaytracer.dart
@@ -36,7 +36,7 @@ import "missing.dart";
  class Vector3f {
      double x, y, z;
 
-     Vector3f(this.x, this.y, this.z);
+     Vector3f([this.x = 0.0, this.y = 0.0, this.z = 0.0]);
 
      double Dot(Vector3f b) {
          return (x * b.x + y * b.y + z * b.z);


### PR DESCRIPTION
Ensure correct 0.0 initialization with optional arguments. Previous version would initialize with `null`.

Remove the only occurrence of Vector3f() constructor call with no arguments. Allocated object was **not** used anyway.
