### PR TITLE
Use constructor initializer list for Ray fields.

### DIFF
--- a/Dart.RaytracerDemo/web/SimpleRaytracer.const.dart
+++ b/Dart.RaytracerDemo/web/SimpleRaytracer.const.dart
@@ -99,10 +99,8 @@ import "missing.dart";
      double closestHitDistance;
      Vector3f hitPoint;
 
-     Ray(Vector3f this.origin, Vector3f this.direction) {
-         closestHitDistance = WORLD_MAX;
-         closestHitObject = null;
-     }
+     Ray(Vector3f this.origin, Vector3f this.direction)
+       :  closestHitDistance = WORLD_MAX;
  }
  
  abstract class RTObject {


### PR DESCRIPTION
This improves the code generated by dart2js. 

Which in turn also allows V8 to figure out that `closestHitDistance` is a property that always contains a number.

No need to initialize `closestHitObject` to `null` explicitly - all fields are `null` initialized by default.
